### PR TITLE
Fixed git version detection on MacOS

### DIFF
--- a/git2net/extraction.py
+++ b/git2net/extraction.py
@@ -1426,7 +1426,7 @@ def mine_git_repo(git_repo_dir, sqlite_db_file, commits=[],
     Returns:
         sqlite database will be written at specified location
     """
-    git_version = check_output(['git', '--version']).strip().split()[-1].decode("utf-8")
+    git_version = check_output(['git', '--version']).strip().decode("utf-8")
 
     parsed_git_version = re.search(r'(\d+)\.(\d+)\.(\d+)', git_version).groups()
 


### PR DESCRIPTION
Git2Net currently crashes on MacOS when mining any cloned repository. This one-line patch fixes that.

Until now, if a user attempts to mine any git repo on MacOS:

```
Traceback (most recent call last):
  File "./test.py", line 10, in <module>
    git2net.mine_git_repo(git_repo_dir, "test.db", max_modifications=100)
  File "/Users/USERNAME/Library/Python/3.7/lib/python/site-packages/git2net/extraction.py", line 1431, in mine_git_repo
    parsed_git_version = re.search(r'(\d+)\.(\d+)\.(\d+)', git_version).groups()
AttributeError: 'NoneType' object has no attribute 'groups'
```

This is because git2net determines the git client version using the following two lines:

https://github.com/gotec/git2net/blob/917eb7b1992d63a58581bf80958d68f115e6d56c/git2net/extraction.py#L1429-L1431

This works on Linux where the version string looks like:

    $ git --version
    git version 2.17.1

But fails on MacOS, where the git version string looks like:

    $ git --version
    git version 2.14.3 (Apple Git-98)


Since you're using regular expressions already, splitting the version string on spaces and applying a regex to just the "2.17.1" portion is unnecessary - we can apply the regex to the entire version string, and extract the first x.y.z version number regardless of position.

With this change, version detection works on both Linux and MacOS.