### PR TITLE
Check if arguments exists in namespace

### DIFF
--- a/git2net/command_line.py
+++ b/git2net/command_line.py
@@ -104,13 +104,13 @@ def main():
     if not args.command:
         raise Exception('Requires command argument: "mine" or "graph".')
     
-    if args.commits:
+    if hasattr(args, 'commits') and args.commits:
         with open(args.commits, 'r') as f:
             args.commits = f.read().split('\n')
             args.commits = [x for x in args.commits if len(x) > 0]
     else:
         args.commits = []
-    if args.exclude:
+    if hasattr(args, 'exclude') and args.exclude:
         with open(args.exclude, 'r') as f:
             args.exclude = f.read().split('\n')
             args.exclude = [x for x in args.exclude if len(x) > 0]


### PR DESCRIPTION
Fixed an issue where calling `git2net graph xxx`  led to an exception, because args.commits is not in the namespace.

That is, because the arguments of subparsers are not picked up and added to the namespace, if they are not called. 
i.e. you need to call `git2net mine xxxx` in order to add all subparser args to the namespace. 
you can verify that behaviour  by inspecting `args` 
