### PR TITLE
Report commit hash when processing errors

### DIFF
--- a/git2net/extraction.py
+++ b/git2net/extraction.py
@@ -1065,6 +1065,7 @@ def _check_mailmap(name, email, git_repo):
         test_str = '<{}>'.format(email)
     else:
         test_str = '{} <{}>'.format(name, email)
+
     out_str = git.Git(str(git_repo.path)).check_mailmap(test_str)
 
     matches = re.findall("^(.*) <(.*)>$", out_str)
@@ -1232,6 +1233,9 @@ def _process_commit(args):
     except KeyboardInterrupt:
         print('Timeout processing commit: ', commit.hash)
         extracted_result = {'commit': pd.DataFrame(), 'edits': pd.DataFrame()}
+    except Exception as e:
+        print('Error processing commit: ',commit.hash)
+        raise
 
     del alarm
 

--- a/git2net/extraction.py
+++ b/git2net/extraction.py
@@ -1232,7 +1232,7 @@ def _process_commit(args):
     except KeyboardInterrupt:
         print('Timeout processing commit: ', commit.hash)
         extracted_result = {'commit': pd.DataFrame(), 'edits': pd.DataFrame()}
-    except Exception as e:
+    except Exception:
         print('Error processing commit: ',commit.hash)
         raise
 

--- a/git2net/extraction.py
+++ b/git2net/extraction.py
@@ -1065,7 +1065,6 @@ def _check_mailmap(name, email, git_repo):
         test_str = '<{}>'.format(email)
     else:
         test_str = '{} <{}>'.format(name, email)
-
     out_str = git.Git(str(git_repo.path)).check_mailmap(test_str)
 
     matches = re.findall("^(.*) <(.*)>$", out_str)


### PR DESCRIPTION
When getting an error through processing, the error is reported in stderr, but the commit hash itself may be useful as well to gather more information about what could be happening.
The global behavior is not changed, as the exception is directly reraised after the print.