### PR TITLE
Speedup of disambiguate : insertion step

### DIFF
--- a/git2net/disambiguation.py
+++ b/git2net/disambiguation.py
@@ -44,8 +44,7 @@ def disambiguate_aliases_db(sqlite_db_file, method='gambit', **quargs):
 
         con.commit()
 
-        for i,r in enumerate(aliases.iterrows()):
-            idx, row = r
+        for idx, row in aliases.iterrows():
             cur.execute("""UPDATE commits
                            SET author_id = :author_id
                            WHERE author_name IS :author_name
@@ -53,9 +52,5 @@ def disambiguate_aliases_db(sqlite_db_file, method='gambit', **quargs):
                         {'author_id': row.author_id,
                          'author_name': row.alias_name,
                          'author_email': row.alias_email})
-            
-            # Committing only every 1000 authors, this speeds up the process
-            if i%1000 == 0:
-                con.commit()
 
         con.commit()

--- a/git2net/disambiguation.py
+++ b/git2net/disambiguation.py
@@ -37,7 +37,13 @@ def disambiguate_aliases_db(sqlite_db_file, method='gambit', **quargs):
         if 'author_id' not in cols:
             cur.execute("""ALTER TABLE commits
                            ADD COLUMN author_id""")
+
+        cur.execute('''
+            CREATE INDEX IF NOT EXISTS author_info_index ON commits(author_name,author_email);
+            ''')
+
         con.commit()
+
         for idx, row in aliases.iterrows():
             cur.execute("""UPDATE commits
                            SET author_id = :author_id

--- a/git2net/disambiguation.py
+++ b/git2net/disambiguation.py
@@ -44,7 +44,8 @@ def disambiguate_aliases_db(sqlite_db_file, method='gambit', **quargs):
 
         con.commit()
 
-        for idx, row in aliases.iterrows():
+        for i,r in enumerate(aliases.iterrows()):
+            idx, row = r
             cur.execute("""UPDATE commits
                            SET author_id = :author_id
                            WHERE author_name IS :author_name
@@ -52,4 +53,9 @@ def disambiguate_aliases_db(sqlite_db_file, method='gambit', **quargs):
                         {'author_id': row.author_id,
                          'author_name': row.alias_name,
                          'author_email': row.alias_email})
-            con.commit()
+            
+            # Committing only every 1000 authors, this speeds up the process
+            if i%1000 == 0:
+                con.commit()
+
+        con.commit()


### PR DESCRIPTION
On a large repo (>10k commits), insertion was taking 80% of the global time necessary (approx 1:50 out of 2:10).
Committing the inserts every 1000 authors instead of every author took down the 1:50 to 0.8s. Adding an index on the relevant columns further reduced this to 0.35s.